### PR TITLE
add load_driver function to eos module

### DIFF
--- a/napalm_eos/__init__.py
+++ b/napalm_eos/__init__.py
@@ -13,3 +13,7 @@
 # the License.
 
 """napalm_eos package."""
+
+def load_driver():
+    return EOSDriver
+


### PR DESCRIPTION
This adds the load_driver funtion to the napalm_eos module so the driver
can be automatically loaded by napalm base.   The load_driver module will
simply return the base class required to allow napalm to instatiate the
network driver

This PR has a dependency on https://github.com/napalm-automation/napalm-base/pull/7
