### PR TITLE
EOS Interface speed fix

### DIFF
--- a/napalm_eos/eos.py
+++ b/napalm_eos/eos.py
@@ -224,7 +224,7 @@ class EOSDriver(NetworkDriver):
 
             interfaces[interface]['last_flapped'] = values.pop('lastStatusChangeTimestamp', None)
 
-            interfaces[interface]['speed'] = values['bandwidth']
+            interfaces[interface]['speed'] = int(values['bandwidth'] * 1e-6)
             interfaces[interface]['mac_address'] = values.pop('physicalAddress', u'')
 
         return interfaces


### PR DESCRIPTION
EOS devices return the speed (field "bandwidth") in bps:

``` json
{
    "interfaces": {
        "Ethernet4/9/3": {
            "lastStatusChangeTimestamp": 1450584893.5729241,
            "name": "Ethernet4/9/3",
            "duplex": "duplexFull",
            "autoNegotiate": "off",
            "burnedInAddress": "00:1c:73:e7:a1:b2",
            "mtu": 9214,
            "hardware": "ethernet",
            "interfaceStatus": "connected",
            "bandwidth": 10000000000
        }
    }
}
```
