### PR TITLE
eOS: get_ntp_servers() replaces get_ntp_peers()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
 - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_lldp_neighbors
 - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_lldp_neighbors_detail
 - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_mac_address_table
-- nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_ntp_peers
+- nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_ntp_servers
 - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_ntp_stats
 - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_route_to
 - nosetests -v TestEOSDriver:TestGetterEOSDriver.test_get_snmp_information

--- a/napalm_eos/eos.py
+++ b/napalm_eos/eos.py
@@ -797,8 +797,7 @@ class EOSDriver(NetworkDriver):
 
         return arp_table
 
-
-    def get_ntp_peers(self):
+    def get_ntp_servers(self):
 
         commands = ['show running-config | section ntp']
 
@@ -807,7 +806,6 @@ class EOSDriver(NetworkDriver):
         ntp_config = napalm_base.helpers.textfsm_extractor(self, 'ntp_peers', raw_ntp_config)
 
         return {unicode(ntp_peer.get('ntppeer')):{} for ntp_peer in ntp_config if ntp_peer.get('ntppeer', '')}
-
 
     def get_ntp_stats(self):
 


### PR DESCRIPTION
Ref: https://github.com/napalm-automation/napalm-base/pull/36
Also see: https://github.com/napalm-automation/napalm-eos/issues/29
