### PR TITLE
pass enablepwd into pyeapi if specified

### DIFF
--- a/napalm_eos/eos.py
+++ b/napalm_eos/eos.py
@@ -60,6 +60,7 @@ class EOSDriver(NetworkDriver):
         if optional_args is None:
             optional_args = {}
         self.port = optional_args.get('port', 443)
+        self.enablepwd = optional_args.get('enablepwd', '')
 
     def open(self):
         """Implemantation of NAPALM method open."""
@@ -72,7 +73,7 @@ class EOSDriver(NetworkDriver):
                 port=self.port,
                 timeout=self.timeout
             )
-            self.device = pyeapi.client.Node(connection)
+            self.device = pyeapi.client.Node(connection, enablepwd=self.enablepwd)
             # does not raise an Exception if unusable
 
             # let's try to run a very simple command

--- a/napalm_eos/eos.py
+++ b/napalm_eos/eos.py
@@ -60,7 +60,7 @@ class EOSDriver(NetworkDriver):
         if optional_args is None:
             optional_args = {}
         self.port = optional_args.get('port', 443)
-        self.enablepwd = optional_args.get('enablepwd', '')
+        self.enablepwd = optional_args.get('enable_password', '')
 
     def open(self):
         """Implemantation of NAPALM method open."""


### PR DESCRIPTION
This fixes the following error when there is an enable password set on the switch:

```
pyeapi.eapilib.CommandError: Error [1005]: CLI command 1 of 2 'enable' failed: permission to run command denied
```

This can be specified like so:

```
device = driver('localhost', 'mchrobak', 'this_is_a_password', optional_args={'enable_password': 'this_is_enable_password'})
```
