### PR TITLE
Clean up and bug fixes

### DIFF
--- a/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/expected_result.json
+++ b/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/expected_result.json
@@ -1,0 +1,370 @@
+{
+  "temperature": {
+    "TempSensor12/1": {
+      "is_alert": false,
+      "temperature": 27.5,
+      "is_critical": false
+    },
+    "TempSensor14/1": {
+      "is_alert": false,
+      "temperature": 28.25,
+      "is_critical": false
+    },
+    "TempSensor16/5": {
+      "is_alert": false,
+      "temperature": 31,
+      "is_critical": false
+    },
+    "TempSensorP1/1": {
+      "is_alert": false,
+      "temperature": 29.625,
+      "is_critical": false
+    },
+    "TempSensorP1/2": {
+      "is_alert": false,
+      "temperature": 22.375,
+      "is_critical": false
+    },
+    "TempSensor1/9": {
+      "is_alert": false,
+      "temperature": 20,
+      "is_critical": false
+    },
+    "TempSensor1/8": {
+      "is_alert": false,
+      "temperature": 21,
+      "is_critical": false
+    },
+    "TempSensorP2/1": {
+      "is_alert": false,
+      "temperature": 28.75,
+      "is_critical": false
+    },
+    "TempSensor3/12": {
+      "is_alert": false,
+      "temperature": 64,
+      "is_critical": false
+    },
+    "TempSensor3/11": {
+      "is_alert": false,
+      "temperature": 48.75,
+      "is_critical": false
+    },
+    "TempSensor3/10": {
+      "is_alert": false,
+      "temperature": 55,
+      "is_critical": false
+    },
+    "TempSensor1/1": {
+      "is_alert": false,
+      "temperature": 28,
+      "is_critical": false
+    },
+    "TempSensor1/3": {
+      "is_alert": false,
+      "temperature": 32,
+      "is_critical": false
+    },
+    "TempSensor1/2": {
+      "is_alert": false,
+      "temperature": 32,
+      "is_critical": false
+    },
+    "TempSensor1/5": {
+      "is_alert": false,
+      "temperature": 26,
+      "is_critical": false
+    },
+    "TempSensor1/4": {
+      "is_alert": false,
+      "temperature": 31,
+      "is_critical": false
+    },
+    "TempSensor1/7": {
+      "is_alert": false,
+      "temperature": 48,
+      "is_critical": false
+    },
+    "TempSensor1/6": {
+      "is_alert": false,
+      "temperature": 49,
+      "is_critical": false
+    },
+    "TempSensor13/3": {
+      "is_alert": false,
+      "temperature": 28.25,
+      "is_critical": false
+    },
+    "TempSensor13/2": {
+      "is_alert": false,
+      "temperature": 24.5,
+      "is_critical": false
+    },
+    "TempSensor13/1": {
+      "is_alert": false,
+      "temperature": 27.75,
+      "is_critical": false
+    },
+    "TempSensorP4/2": {
+      "is_alert": false,
+      "temperature": 23.75,
+      "is_critical": false
+    },
+    "TempSensor3/9": {
+      "is_alert": false,
+      "temperature": 62.25,
+      "is_critical": false
+    },
+    "TempSensor3/8": {
+      "is_alert": false,
+      "temperature": 55.5,
+      "is_critical": false
+    },
+    "TempSensor3/7": {
+      "is_alert": false,
+      "temperature": 54,
+      "is_critical": false
+    },
+    "TempSensor3/6": {
+      "is_alert": false,
+      "temperature": 62,
+      "is_critical": false
+    },
+    "TempSensor3/5": {
+      "is_alert": false,
+      "temperature": 51.5,
+      "is_critical": false
+    },
+    "TempSensor3/4": {
+      "is_alert": false,
+      "temperature": 53,
+      "is_critical": false
+    },
+    "TempSensor3/3": {
+      "is_alert": false,
+      "temperature": 34.75,
+      "is_critical": false
+    },
+    "TempSensor3/2": {
+      "is_alert": false,
+      "temperature": 55.25,
+      "is_critical": false
+    },
+    "TempSensor3/1": {
+      "is_alert": false,
+      "temperature": 25.75,
+      "is_critical": false
+    },
+    "TempSensor12/5": {
+      "is_alert": false,
+      "temperature": 30,
+      "is_critical": false
+    },
+    "TempSensor11/5": {
+      "is_alert": false,
+      "temperature": 29,
+      "is_critical": false
+    },
+    "TempSensor11/4": {
+      "is_alert": false,
+      "temperature": 32,
+      "is_critical": false
+    },
+    "TempSensor11/1": {
+      "is_alert": false,
+      "temperature": 27.75,
+      "is_critical": false
+    },
+    "TempSensorP3/2": {
+      "is_alert": false,
+      "temperature": 23.125,
+      "is_critical": false
+    },
+    "TempSensor11/3": {
+      "is_alert": false,
+      "temperature": 28.5,
+      "is_critical": false
+    },
+    "TempSensor11/2": {
+      "is_alert": false,
+      "temperature": 24.5,
+      "is_critical": false
+    },
+    "TempSensor15/1": {
+      "is_alert": false,
+      "temperature": 28,
+      "is_critical": false
+    },
+    "TempSensor15/3": {
+      "is_alert": false,
+      "temperature": 28.5,
+      "is_critical": false
+    },
+    "TempSensor15/2": {
+      "is_alert": false,
+      "temperature": 24.75,
+      "is_critical": false
+    },
+    "TempSensor15/5": {
+      "is_alert": false,
+      "temperature": 30,
+      "is_critical": false
+    },
+    "TempSensor15/4": {
+      "is_alert": false,
+      "temperature": 33,
+      "is_critical": false
+    },
+    "TempSensor1/11": {
+      "is_alert": false,
+      "temperature": 27,
+      "is_critical": false
+    },
+    "TempSensor1/10": {
+      "is_alert": false,
+      "temperature": 27,
+      "is_critical": false
+    },
+    "TempSensor14/2": {
+      "is_alert": false,
+      "temperature": 24.75,
+      "is_critical": false
+    },
+    "TempSensor14/3": {
+      "is_alert": false,
+      "temperature": 28.5,
+      "is_critical": false
+    },
+    "TempSensor14/4": {
+      "is_alert": false,
+      "temperature": 33,
+      "is_critical": false
+    },
+    "TempSensor14/5": {
+      "is_alert": false,
+      "temperature": 29,
+      "is_critical": false
+    },
+    "TempSensorP4/1": {
+      "is_alert": false,
+      "temperature": 30,
+      "is_critical": false
+    },
+    "TempSensor16/4": {
+      "is_alert": false,
+      "temperature": 33,
+      "is_critical": false
+    },
+    "TempSensor12/4": {
+      "is_alert": false,
+      "temperature": 32,
+      "is_critical": false
+    },
+    "TempSensor16/2": {
+      "is_alert": false,
+      "temperature": 27,
+      "is_critical": false
+    },
+    "TempSensor16/3": {
+      "is_alert": false,
+      "temperature": 29.75,
+      "is_critical": false
+    },
+    "TempSensor16/1": {
+      "is_alert": false,
+      "temperature": 28.25,
+      "is_critical": false
+    },
+    "TempSensorP3/1": {
+      "is_alert": false,
+      "temperature": 30.375,
+      "is_critical": false
+    },
+    "TempSensor13/5": {
+      "is_alert": false,
+      "temperature": 30,
+      "is_critical": false
+    },
+    "TempSensorP2/2": {
+      "is_alert": false,
+      "temperature": 22.25,
+      "is_critical": false
+    },
+    "TempSensor13/4": {
+      "is_alert": false,
+      "temperature": 32,
+      "is_critical": false
+    },
+    "TempSensor12/2": {
+      "is_alert": false,
+      "temperature": 24.25,
+      "is_critical": false
+    },
+    "TempSensor12/3": {
+      "is_alert": false,
+      "temperature": 28.5,
+      "is_critical": false
+    },
+    "TempSensor2": {
+      "is_alert": false, 
+      "temperature": 35.0, 
+      "is_critical": false
+    }, 
+    "TempSensor1": {
+      "is_alert": false, 
+      "temperature": 41.63677939132518, 
+      "is_critical": false
+    }
+  },
+  "power": {
+    "1": {
+      "status": true,
+      "output": 296,
+      "capacity": 2900
+    },
+    "2": {
+      "status": true,
+      "output": 212,
+      "capacity": 2900
+    },
+    "3": {
+      "status": true,
+      "output": 212,
+      "capacity": 2900
+    },
+    "4": {
+      "status": true,
+      "output": 212,
+      "capacity": 2900
+    }
+  },
+  "fans": {
+    "1": {
+      "status": true
+    },
+    "2": {
+      "status": true
+    },
+    "3": {
+      "status": true
+    },
+    "4": {
+      "status": true
+    },
+    "5": {
+      "status": true
+    },
+    "6": {
+      "status": true
+    }
+  },
+  "memory": {
+    "available_ram": 26775428,
+    "used_ram": 5696652
+  },
+  "cpu": {
+    "0": {
+      "%usage": 5.4 
+    }
+  }
+}

--- a/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/report.json
+++ b/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/report.json
@@ -1,0 +1,1 @@
+{"included": [], "data": [{"relationships": {"tests": {"data": []}}, "attributes": {"environment": {}, "created_at": "2016-11-04 13:15:34.112786", "summary": {"duration": 0.006936073303222656, "num_tests": 0}}, "type": "report", "id": 1}]}

--- a/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/show_environment_cooling.json
+++ b/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/show_environment_cooling.json
@@ -1,0 +1,286 @@
+{
+    "overrideFanSpeed": 0,
+    "coolingMode": "automatic",
+    "powerSupplySlots": [
+        {
+            "status": "ok",
+            "fans": [
+                {
+                    "status": "ok",
+                    "configuredSpeed": 70,
+                    "actualSpeed": 68,
+                    "label": "PowerSupply1/1"
+                }
+            ],
+            "speed": 70,
+            "label": "PowerSupply1"
+        },
+        {
+            "status": "ok",
+            "fans": [
+                {
+                    "status": "ok",
+                    "configuredSpeed": 70,
+                    "actualSpeed": 68,
+                    "label": "PowerSupply2/1"
+                }
+            ],
+            "speed": 70,
+            "label": "PowerSupply2"
+        },
+        {
+            "status": "ok",
+            "fans": [
+                {
+                    "status": "ok",
+                    "configuredSpeed": 70,
+                    "actualSpeed": 70,
+                    "label": "PowerSupply3/1"
+                }
+            ],
+            "speed": 70,
+            "label": "PowerSupply3"
+        },
+        {
+            "status": "ok",
+            "fans": [
+                {
+                    "status": "ok",
+                    "configuredSpeed": 70,
+                    "actualSpeed": 69,
+                    "label": "PowerSupply4/1"
+                }
+            ],
+            "speed": 70,
+            "label": "PowerSupply4"
+        }
+    ],
+    "fanTraySlots": [
+        {
+            "status": "ok",
+            "fans": [
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "1/1"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "1/2"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "1/3"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "1/4"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "1/5"
+                }
+            ],
+            "speed": 42,
+            "label": "1"
+        },
+        {
+            "status": "ok",
+            "fans": [
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "2/1"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "2/2"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 42,
+                    "label": "2/3"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 42,
+                    "label": "2/4"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 42,
+                    "label": "2/5"
+                }
+            ],
+            "speed": 42,
+            "label": "2"
+        },
+        {
+            "status": "ok",
+            "fans": [
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "3/1"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "3/2"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "3/3"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 42,
+                    "label": "3/4"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 42,
+                    "label": "3/5"
+                }
+            ],
+            "speed": 42,
+            "label": "3"
+        },
+        {
+            "status": "ok",
+            "fans": [
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 42,
+                    "label": "4/1"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "4/2"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "4/3"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "4/4"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "4/5"
+                }
+            ],
+            "speed": 42,
+            "label": "4"
+        },
+        {
+            "status": "ok",
+            "fans": [
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "5/1"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "5/2"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 42,
+                    "label": "5/3"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 42,
+                    "label": "5/4"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "5/5"
+                }
+            ],
+            "speed": 42,
+            "label": "5"
+        },
+        {
+            "status": "ok",
+            "fans": [
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "6/1"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "6/2"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "6/3"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 42,
+                    "label": "6/4"
+                },
+                {
+                    "status": "ok",
+                    "configuredSpeed": 42,
+                    "actualSpeed": 41,
+                    "label": "6/5"
+                }
+            ],
+            "speed": 42,
+            "label": "6"
+        }
+    ],
+    "ambientTemperature": 20.0,
+    "shutdownOnInsufficientFans": true,
+    "systemStatus": "coolingOk",
+    "airflowDirection": "frontToBackAirflow"
+}

--- a/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/show_environment_power.json
+++ b/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/show_environment_power.json
@@ -1,0 +1,104 @@
+{
+    "powerSupplies": {
+        "1": {
+            "outputPower": 296.0,
+            "fans": {
+                "FanP1/1": {
+                    "status": "ok",
+                    "speed": 69
+                }
+            },
+            "modelName": "PWR-2900AC",
+            "capacity": 2900.0,
+            "inputCurrent": 1.71875,
+            "tempSensors": {
+                "TempSensorP1/2": {
+                    "status": "ok",
+                    "temperature": 22.375
+                },
+                "TempSensorP1/1": {
+                    "status": "ok",
+                    "temperature": 29.5
+                }
+            },
+            "managed": true,
+            "outputCurrent": 24.72,
+            "state": "ok"
+        },
+        "3": {
+            "outputPower": 212.0,
+            "fans": {
+                "FanP3/1": {
+                    "status": "ok",
+                    "speed": 69
+                }
+            },
+            "modelName": "PWR-2900AC",
+            "capacity": 2900.0,
+            "inputCurrent": 1.40625,
+            "tempSensors": {
+                "TempSensorP3/1": {
+                    "status": "ok",
+                    "temperature": 29.875
+                },
+                "TempSensorP3/2": {
+                    "status": "ok",
+                    "temperature": 23.25
+                }
+            },
+            "managed": true,
+            "outputCurrent": 17.740000000000002,
+            "state": "ok"
+        },
+        "2": {
+            "outputPower": 212.0,
+            "fans": {
+                "FanP2/1": {
+                    "status": "ok",
+                    "speed": 69
+                }
+            },
+            "modelName": "PWR-2900AC",
+            "capacity": 2900.0,
+            "inputCurrent": 1.34375,
+            "tempSensors": {
+                "TempSensorP2/1": {
+                    "status": "ok",
+                    "temperature": 29.125
+                },
+                "TempSensorP2/2": {
+                    "status": "ok",
+                    "temperature": 22.25
+                }
+            },
+            "managed": true,
+            "outputCurrent": 17.84,
+            "state": "ok"
+        },
+        "4": {
+            "outputPower": 212.0,
+            "fans": {
+                "FanP4/1": {
+                    "status": "ok",
+                    "speed": 69
+                }
+            },
+            "modelName": "PWR-2900AC",
+            "capacity": 2900.0,
+            "inputCurrent": 1.53125,
+            "tempSensors": {
+                "TempSensorP4/2": {
+                    "status": "ok",
+                    "temperature": 24.0
+                },
+                "TempSensorP4/1": {
+                    "status": "ok",
+                    "temperature": 30.25
+                }
+            },
+            "managed": true,
+            "outputCurrent": 17.96,
+            "state": "ok"
+        }
+    }
+}

--- a/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/show_environment_temperature.json
+++ b/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/show_environment_temperature.json
@@ -1,0 +1,901 @@
+{
+    "cardSlots": [
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 46.0,
+                    "maxTemperatureLastChange": 1437583421.9598742,
+                    "hwStatus": "ok",
+                    "description": "Digital Temperature Sensor on cpu0",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor1/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 28.0
+                },
+                {
+                    "maxTemperature": 52.0,
+                    "maxTemperatureLastChange": 1437583156.9341135,
+                    "hwStatus": "ok",
+                    "description": "Digital Temperature Sensor on cpu1",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor1/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 32.0
+                },
+                {
+                    "maxTemperature": 52.0,
+                    "maxTemperatureLastChange": 1437583156.9341378,
+                    "hwStatus": "ok",
+                    "description": "Digital Temperature Sensor on cpu2",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor1/3",
+                    "inAlertState": false,
+                    "relPos": "3",
+                    "alertCount": 0,
+                    "currentTemperature": 32.0
+                },
+                {
+                    "maxTemperature": 51.0,
+                    "maxTemperatureLastChange": 1437583156.9340882,
+                    "hwStatus": "ok",
+                    "description": "Digital Temperature Sensor on cpu3",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor1/4",
+                    "inAlertState": false,
+                    "relPos": "4",
+                    "alertCount": 0,
+                    "currentTemperature": 31.0
+                },
+                {
+                    "maxTemperature": 29.0,
+                    "maxTemperatureLastChange": 1447409199.1607616,
+                    "hwStatus": "ok",
+                    "description": "Supervisor temp sensor",
+                    "overheatThreshold": 75.0,
+                    "criticalThreshold": 85.0,
+                    "name": "TempSensor1/5",
+                    "inAlertState": false,
+                    "relPos": "5",
+                    "alertCount": 0,
+                    "currentTemperature": 26.0
+                },
+                {
+                    "maxTemperature": 52.0,
+                    "maxTemperatureLastChange": 1448204929.102181,
+                    "hwStatus": "ok",
+                    "description": "PlxLc sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 103.0,
+                    "name": "TempSensor1/6",
+                    "inAlertState": false,
+                    "relPos": "6",
+                    "alertCount": 0,
+                    "currentTemperature": 49.0
+                },
+                {
+                    "maxTemperature": 52.0,
+                    "maxTemperatureLastChange": 1447409179.1398125,
+                    "hwStatus": "ok",
+                    "description": "PlxFc sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 103.0,
+                    "name": "TempSensor1/7",
+                    "inAlertState": false,
+                    "relPos": "7",
+                    "alertCount": 0,
+                    "currentTemperature": 48.0
+                },
+                {
+                    "maxTemperature": 24.0,
+                    "maxTemperatureLastChange": 1448275657.4751613,
+                    "hwStatus": "ok",
+                    "description": "Rear sensor",
+                    "overheatThreshold": 65.0,
+                    "criticalThreshold": 75.0,
+                    "name": "TempSensor1/8",
+                    "inAlertState": false,
+                    "relPos": "8",
+                    "alertCount": 0,
+                    "currentTemperature": 21.0
+                },
+                {
+                    "maxTemperature": 23.0,
+                    "maxTemperatureLastChange": 1448274501.2003179,
+                    "hwStatus": "ok",
+                    "description": "Front sensor",
+                    "overheatThreshold": 65.0,
+                    "criticalThreshold": 75.0,
+                    "name": "TempSensor1/9",
+                    "inAlertState": false,
+                    "relPos": "9",
+                    "alertCount": 0,
+                    "currentTemperature": 20.0
+                },
+                {
+                    "maxTemperature": 31.0,
+                    "maxTemperatureLastChange": 1437583528.221005,
+                    "hwStatus": "ok",
+                    "description": "CPU VRM temp sensor 0",
+                    "overheatThreshold": 105.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor1/10",
+                    "inAlertState": false,
+                    "relPos": "10",
+                    "alertCount": 0,
+                    "currentTemperature": 27.0
+                },
+                {
+                    "maxTemperature": 31.0,
+                    "maxTemperatureLastChange": 1437583528.2210116,
+                    "hwStatus": "ok",
+                    "description": "CPU VRM temp sensor 1",
+                    "overheatThreshold": 105.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor1/11",
+                    "inAlertState": false,
+                    "relPos": "11",
+                    "alertCount": 0,
+                    "currentTemperature": 27.0
+                }
+            ],
+            "entPhysicalClass": "Supervisor",
+            "relPos": "1"
+        },
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 29.25,
+                    "maxTemperatureLastChange": 1437583598.7151737,
+                    "hwStatus": "ok",
+                    "description": "Inlet sensor",
+                    "overheatThreshold": 60.0,
+                    "criticalThreshold": 70.0,
+                    "name": "TempSensor3/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 25.75
+                },
+                {
+                    "maxTemperature": 59.0,
+                    "maxTemperatureLastChange": 1447129800.86387,
+                    "hwStatus": "ok",
+                    "description": "Board sensor",
+                    "overheatThreshold": 75.0,
+                    "criticalThreshold": 85.0,
+                    "name": "TempSensor3/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 55.25
+                },
+                {
+                    "maxTemperature": 37.75,
+                    "maxTemperatureLastChange": 1439067314.4993434,
+                    "hwStatus": "ok",
+                    "description": "Outlet sensor",
+                    "overheatThreshold": 75.0,
+                    "criticalThreshold": 85.0,
+                    "name": "TempSensor3/3",
+                    "inAlertState": false,
+                    "relPos": "3",
+                    "alertCount": 0,
+                    "currentTemperature": 34.75
+                },
+                {
+                    "maxTemperature": 57.0,
+                    "maxTemperatureLastChange": 1447129807.9957194,
+                    "hwStatus": "ok",
+                    "description": "Board sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor3/4",
+                    "inAlertState": false,
+                    "relPos": "4",
+                    "alertCount": 0,
+                    "currentTemperature": 53.0
+                },
+                {
+                    "maxTemperature": 57.75,
+                    "maxTemperatureLastChange": 1437583619.612965,
+                    "hwStatus": "ok",
+                    "description": "Switch chip 1 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor3/5",
+                    "inAlertState": false,
+                    "relPos": "5",
+                    "alertCount": 0,
+                    "currentTemperature": 51.5
+                },
+                {
+                    "maxTemperature": 67.0,
+                    "maxTemperatureLastChange": 1438207344.8952332,
+                    "hwStatus": "ok",
+                    "description": "Switch chip 2 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor3/6",
+                    "inAlertState": false,
+                    "relPos": "6",
+                    "alertCount": 0,
+                    "currentTemperature": 62.0
+                },
+                {
+                    "maxTemperature": 58.0,
+                    "maxTemperatureLastChange": 1448121955.436718,
+                    "hwStatus": "ok",
+                    "description": "Board sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor3/7",
+                    "inAlertState": false,
+                    "relPos": "7",
+                    "alertCount": 0,
+                    "currentTemperature": 54.0
+                },
+                {
+                    "maxTemperature": 60.75,
+                    "maxTemperatureLastChange": 1437583624.6120057,
+                    "hwStatus": "ok",
+                    "description": "Switch chip 3 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor3/8",
+                    "inAlertState": false,
+                    "relPos": "8",
+                    "alertCount": 0,
+                    "currentTemperature": 55.5
+                },
+                {
+                    "maxTemperature": 67.25,
+                    "maxTemperatureLastChange": 1448121942.374377,
+                    "hwStatus": "ok",
+                    "description": "Switch chip 4 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor3/9",
+                    "inAlertState": false,
+                    "relPos": "9",
+                    "alertCount": 0,
+                    "currentTemperature": 62.25
+                },
+                {
+                    "maxTemperature": 58.0,
+                    "maxTemperatureLastChange": 1448202173.9825656,
+                    "hwStatus": "ok",
+                    "description": "Board sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor3/10",
+                    "inAlertState": false,
+                    "relPos": "10",
+                    "alertCount": 0,
+                    "currentTemperature": 55.0
+                },
+                {
+                    "maxTemperature": 56.0,
+                    "maxTemperatureLastChange": 1437583614.603508,
+                    "hwStatus": "ok",
+                    "description": "Switch chip 5 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor3/11",
+                    "inAlertState": false,
+                    "relPos": "11",
+                    "alertCount": 0,
+                    "currentTemperature": 48.75
+                },
+                {
+                    "maxTemperature": 68.75,
+                    "maxTemperatureLastChange": 1448121955.4413555,
+                    "hwStatus": "ok",
+                    "description": "Switch chip 6 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 110.0,
+                    "name": "TempSensor3/12",
+                    "inAlertState": false,
+                    "relPos": "12",
+                    "alertCount": 0,
+                    "currentTemperature": 64.0
+                }
+            ],
+            "entPhysicalClass": "Linecard",
+            "relPos": "3"
+        },
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 32.0,
+                    "maxTemperatureLastChange": 1437583617.816358,
+                    "hwStatus": "ok",
+                    "description": "Outlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor11/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 27.75
+                },
+                {
+                    "maxTemperature": 28.0,
+                    "maxTemperatureLastChange": 1441487427.119975,
+                    "hwStatus": "ok",
+                    "description": "Inlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor11/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 24.5
+                },
+                {
+                    "maxTemperature": 33.0,
+                    "maxTemperatureLastChange": 1437583629.7917063,
+                    "hwStatus": "ok",
+                    "description": "Board sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor11/3",
+                    "inAlertState": false,
+                    "relPos": "3",
+                    "alertCount": 0,
+                    "currentTemperature": 28.5
+                },
+                {
+                    "maxTemperature": 37.0,
+                    "maxTemperatureLastChange": 1441487361.326174,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 1 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor11/4",
+                    "inAlertState": false,
+                    "relPos": "4",
+                    "alertCount": 0,
+                    "currentTemperature": 32.0
+                },
+                {
+                    "maxTemperature": 34.0,
+                    "maxTemperatureLastChange": 1441487441.3293684,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 2 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor11/5",
+                    "inAlertState": false,
+                    "relPos": "5",
+                    "alertCount": 0,
+                    "currentTemperature": 29.0
+                }
+            ],
+            "entPhysicalClass": "Fabric",
+            "relPos": "1"
+        },
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 32.0,
+                    "maxTemperatureLastChange": 1437583591.7713757,
+                    "hwStatus": "ok",
+                    "description": "Outlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor12/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 27.5
+                },
+                {
+                    "maxTemperature": 27.75,
+                    "maxTemperatureLastChange": 1437583643.0048025,
+                    "hwStatus": "ok",
+                    "description": "Inlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor12/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 24.25
+                },
+                {
+                    "maxTemperature": 33.5,
+                    "maxTemperatureLastChange": 1437583586.3524427,
+                    "hwStatus": "ok",
+                    "description": "Board sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor12/3",
+                    "inAlertState": false,
+                    "relPos": "3",
+                    "alertCount": 0,
+                    "currentTemperature": 28.5
+                },
+                {
+                    "maxTemperature": 37.0,
+                    "maxTemperatureLastChange": 1441556470.6309335,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 1 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor12/4",
+                    "inAlertState": false,
+                    "relPos": "4",
+                    "alertCount": 0,
+                    "currentTemperature": 32.0
+                },
+                {
+                    "maxTemperature": 35.0,
+                    "maxTemperatureLastChange": 1441487381.328109,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 2 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor12/5",
+                    "inAlertState": false,
+                    "relPos": "5",
+                    "alertCount": 0,
+                    "currentTemperature": 30.0
+                }
+            ],
+            "entPhysicalClass": "Fabric",
+            "relPos": "2"
+        },
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 32.25,
+                    "maxTemperatureLastChange": 1437583586.3418207,
+                    "hwStatus": "ok",
+                    "description": "Outlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor13/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 27.75
+                },
+                {
+                    "maxTemperature": 28.0,
+                    "maxTemperatureLastChange": 1437583642.9943464,
+                    "hwStatus": "ok",
+                    "description": "Inlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor13/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 24.5
+                },
+                {
+                    "maxTemperature": 32.75,
+                    "maxTemperatureLastChange": 1437583611.5365534,
+                    "hwStatus": "ok",
+                    "description": "Board sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor13/3",
+                    "inAlertState": false,
+                    "relPos": "3",
+                    "alertCount": 0,
+                    "currentTemperature": 28.25
+                },
+                {
+                    "maxTemperature": 37.0,
+                    "maxTemperatureLastChange": 1441489636.5117283,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 1 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor13/4",
+                    "inAlertState": false,
+                    "relPos": "4",
+                    "alertCount": 0,
+                    "currentTemperature": 32.0
+                },
+                {
+                    "maxTemperature": 35.0,
+                    "maxTemperatureLastChange": 1441488461.4214644,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 2 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor13/5",
+                    "inAlertState": false,
+                    "relPos": "5",
+                    "alertCount": 0,
+                    "currentTemperature": 30.0
+                }
+            ],
+            "entPhysicalClass": "Fabric",
+            "relPos": "3"
+        },
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 32.25,
+                    "maxTemperatureLastChange": 1437583629.8022814,
+                    "hwStatus": "ok",
+                    "description": "Outlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor14/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 28.25
+                },
+                {
+                    "maxTemperature": 28.0,
+                    "maxTemperatureLastChange": 1437583617.8269086,
+                    "hwStatus": "ok",
+                    "description": "Inlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor14/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 24.75
+                },
+                {
+                    "maxTemperature": 33.0,
+                    "maxTemperatureLastChange": 1437583591.7814753,
+                    "hwStatus": "ok",
+                    "description": "Board sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor14/3",
+                    "inAlertState": false,
+                    "relPos": "3",
+                    "alertCount": 0,
+                    "currentTemperature": 28.5
+                },
+                {
+                    "maxTemperature": 37.0,
+                    "maxTemperatureLastChange": 1441488556.4277143,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 1 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor14/4",
+                    "inAlertState": false,
+                    "relPos": "4",
+                    "alertCount": 0,
+                    "currentTemperature": 33.0
+                },
+                {
+                    "maxTemperature": 34.0,
+                    "maxTemperatureLastChange": 1441488756.4354422,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 2 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor14/5",
+                    "inAlertState": false,
+                    "relPos": "5",
+                    "alertCount": 0,
+                    "currentTemperature": 29.0
+                }
+            ],
+            "entPhysicalClass": "Fabric",
+            "relPos": "4"
+        },
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 32.25,
+                    "maxTemperatureLastChange": 1437583611.5469427,
+                    "hwStatus": "ok",
+                    "description": "Outlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor15/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 28.0
+                },
+                {
+                    "maxTemperature": 27.75,
+                    "maxTemperatureLastChange": 1437583661.268155,
+                    "hwStatus": "ok",
+                    "description": "Inlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor15/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 24.75
+                },
+                {
+                    "maxTemperature": 32.75,
+                    "maxTemperatureLastChange": 1437583586.3523726,
+                    "hwStatus": "ok",
+                    "description": "Board sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor15/3",
+                    "inAlertState": false,
+                    "relPos": "3",
+                    "alertCount": 0,
+                    "currentTemperature": 28.5
+                },
+                {
+                    "maxTemperature": 37.0,
+                    "maxTemperatureLastChange": 1441488486.42269,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 1 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor15/4",
+                    "inAlertState": false,
+                    "relPos": "4",
+                    "alertCount": 0,
+                    "currentTemperature": 33.0
+                },
+                {
+                    "maxTemperature": 33.0,
+                    "maxTemperatureLastChange": 1441556555.6321013,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 2 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor15/5",
+                    "inAlertState": false,
+                    "relPos": "5",
+                    "alertCount": 0,
+                    "currentTemperature": 30.0
+                }
+            ],
+            "entPhysicalClass": "Fabric",
+            "relPos": "5"
+        },
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 32.25,
+                    "maxTemperatureLastChange": 1437583605.4615312,
+                    "hwStatus": "ok",
+                    "description": "Outlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor16/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 28.25
+                },
+                {
+                    "maxTemperature": 29.75,
+                    "maxTemperatureLastChange": 1441488558.4321597,
+                    "hwStatus": "ok",
+                    "description": "Inlet sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor16/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 27.0
+                },
+                {
+                    "maxTemperature": 33.5,
+                    "maxTemperatureLastChange": 1437583623.1854844,
+                    "hwStatus": "ok",
+                    "description": "Board sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor16/3",
+                    "inAlertState": false,
+                    "relPos": "3",
+                    "alertCount": 0,
+                    "currentTemperature": 29.75
+                },
+                {
+                    "maxTemperature": 37.0,
+                    "maxTemperatureLastChange": 1441556500.6320963,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 1 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor16/4",
+                    "inAlertState": false,
+                    "relPos": "4",
+                    "alertCount": 0,
+                    "currentTemperature": 33.0
+                },
+                {
+                    "maxTemperature": 35.0,
+                    "maxTemperatureLastChange": 1441489651.5134578,
+                    "hwStatus": "ok",
+                    "description": "Fan controller 2 sensor",
+                    "overheatThreshold": 95.0,
+                    "criticalThreshold": 105.0,
+                    "name": "TempSensor16/5",
+                    "inAlertState": false,
+                    "relPos": "5",
+                    "alertCount": 0,
+                    "currentTemperature": 31.0
+                }
+            ],
+            "entPhysicalClass": "Fabric",
+            "relPos": "6"
+        }
+    ],
+    "powerSupplySlots": [
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 41.125,
+                    "maxTemperatureLastChange": 1440032303.0436726,
+                    "hwStatus": "ok",
+                    "description": "Power supply sensor",
+                    "overheatThreshold": 65.0,
+                    "criticalThreshold": 70.0,
+                    "name": "TempSensorP1/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 29.625
+                },
+                {
+                    "maxTemperature": 24.625,
+                    "maxTemperatureLastChange": 1441488537.2046435,
+                    "hwStatus": "ok",
+                    "description": "Power supply sensor",
+                    "overheatThreshold": 65.0,
+                    "criticalThreshold": 70.0,
+                    "name": "TempSensorP1/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 22.375
+                }
+            ],
+            "entPhysicalClass": "PowerSupply",
+            "relPos": "1"
+        },
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 41.375,
+                    "maxTemperatureLastChange": 1440150172.225087,
+                    "hwStatus": "ok",
+                    "description": "Power supply sensor",
+                    "overheatThreshold": 65.0,
+                    "criticalThreshold": 70.0,
+                    "name": "TempSensorP2/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 28.75
+                },
+                {
+                    "maxTemperature": 24.75,
+                    "maxTemperatureLastChange": 1438819715.119814,
+                    "hwStatus": "ok",
+                    "description": "Power supply sensor",
+                    "overheatThreshold": 65.0,
+                    "criticalThreshold": 70.0,
+                    "name": "TempSensorP2/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 22.25
+                }
+            ],
+            "entPhysicalClass": "PowerSupply",
+            "relPos": "2"
+        },
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 42.75,
+                    "maxTemperatureLastChange": 1444591985.1574292,
+                    "hwStatus": "ok",
+                    "description": "Power supply sensor",
+                    "overheatThreshold": 65.0,
+                    "criticalThreshold": 70.0,
+                    "name": "TempSensorP3/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 30.375
+                },
+                {
+                    "maxTemperature": 25.25,
+                    "maxTemperatureLastChange": 1441488587.6122668,
+                    "hwStatus": "ok",
+                    "description": "Power supply sensor",
+                    "overheatThreshold": 65.0,
+                    "criticalThreshold": 70.0,
+                    "name": "TempSensorP3/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 23.125
+                }
+            ],
+            "entPhysicalClass": "PowerSupply",
+            "relPos": "3"
+        },
+        {
+            "tempSensors": [
+                {
+                    "maxTemperature": 43.25,
+                    "maxTemperatureLastChange": 1438274685.6674328,
+                    "hwStatus": "ok",
+                    "description": "Power supply sensor",
+                    "overheatThreshold": 65.0,
+                    "criticalThreshold": 70.0,
+                    "name": "TempSensorP4/1",
+                    "inAlertState": false,
+                    "relPos": "1",
+                    "alertCount": 0,
+                    "currentTemperature": 30.0
+                },
+                {
+                    "maxTemperature": 26.0,
+                    "maxTemperatureLastChange": 1447652810.2495797,
+                    "hwStatus": "ok",
+                    "description": "Power supply sensor",
+                    "overheatThreshold": 65.0,
+                    "criticalThreshold": 70.0,
+                    "name": "TempSensorP4/2",
+                    "inAlertState": false,
+                    "relPos": "2",
+                    "alertCount": 0,
+                    "currentTemperature": 23.75
+                }
+            ],
+            "entPhysicalClass": "PowerSupply",
+            "relPos": "4"
+        }
+    ],
+    "shutdownOnOverheat": true,
+    "tempSensors": [
+       {
+            "maxTemperature": 48.21273929067406, 
+            "maxTemperatureLastChange": 1473779176.7382116, 
+            "hwStatus": "ok", 
+            "currentTemperature": 41.63677939132518, 
+            "description": "Cpu temp sensor", 
+            "overheatThreshold": 90.0, 
+            "criticalThreshold": 95.0, 
+            "inAlertState": false, 
+            "relPos": "1", 
+            "alertCount": 0, 
+            "name": "TempSensor1"
+        }, 
+        {
+            "maxTemperature": 38.0, 
+            "maxTemperatureLastChange": 1473853425.4411056, 
+            "hwStatus": "ok", 
+            "currentTemperature": 35.0, 
+            "description": "CPU board temp sensor", 
+            "overheatThreshold": 75.0, 
+            "criticalThreshold": 80.0, 
+            "inAlertState": false, 
+            "relPos": "2", 
+            "alertCount": 0, 
+            "name": "TempSensor2"
+        } 
+    ],
+    "systemStatus": "temperatureOk"
+}

--- a/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/show_processes_top_once.text
+++ b/test/unit/mocked_data/test_get_environment/issue80_stacktrace_for_get_environment/show_processes_top_once.text
@@ -1,0 +1,14 @@
+top - 12:14:45 up 30 days,  1:28,  3 users,  load average: 0.05, 0.14, 0.20
+Tasks: 297 total,   2 running, 295 sleeping,   0 stopped,   0 zombie
+%Cpu(s):  4.2 us,  0.9 sy,  0.0 ni, 94.6 id,  0.0 wa,  0.1 hi,  0.2 si,  0.0 st
+KiB Mem:  32472080 total,  5696652 used, 26775428 free,   372092 buffers
+KiB Swap:        0 total,        0 used,        0 free,  2602532 cached
+
+  PID USER      PR  NI  VIRT  RES  SHR S  %CPU %MEM    TIME+  COMMAND
+16136 loke      20   0 25864  12m 9016 R   8.3  0.0   0:00.11 top
+ 2392 root      20   0  3860 1104  848 S   4.1  0.0  34:44.61 EosOomAdjust
+    1 root      20   0  7940 4036 2492 S   0.0  0.0   2:23.32 systemd
+    2 root      20   0     0    0    0 S   0.0  0.0   0:00.02 kthreadd
+    3 root      20   0     0    0    0 S   0.0  0.0   0:00.68 ksoftirqd/0
+    6 root      rt   0     0    0    0 S   0.0  0.0   0:05.75 migration/0
+

--- a/test/unit/mocked_data/test_get_environment/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_environment/normal/expected_result.json
@@ -304,6 +304,16 @@
       "is_alert": false,
       "temperature": 28.5,
       "is_critical": false
+    },
+    "TempSensor2": {
+      "is_alert": false, 
+      "temperature": 35.0, 
+      "is_critical": false
+    }, 
+    "TempSensor1": {
+      "is_alert": false, 
+      "temperature": 41.63677939132518, 
+      "is_critical": false
     }
   },
   "power": {
@@ -328,8 +338,6 @@
       "capacity": 2900
     }
   },
-  "used_ram": "",
-  "available_ram": "",
   "fans": {
     "1": {
       "status": true
@@ -351,12 +359,12 @@
     }
   },
   "memory": {
-    "available_ram": 16012300,
+    "available_ram": 11431608,
     "used_ram": 4580692
   },
   "cpu": {
     "0": {
-      "%usage": 3.5
+      "%usage": 4.3
     }
   }
 }

--- a/test/unit/mocked_data/test_get_environment/normal/show_environment_temperature.json
+++ b/test/unit/mocked_data/test_get_environment/normal/show_environment_temperature.json
@@ -869,6 +869,33 @@
         }
     ],
     "shutdownOnOverheat": true,
-    "tempSensors": [],
+    "tempSensors": [
+       {
+            "maxTemperature": 48.21273929067406, 
+            "maxTemperatureLastChange": 1473779176.7382116, 
+            "hwStatus": "ok", 
+            "currentTemperature": 41.63677939132518, 
+            "description": "Cpu temp sensor", 
+            "overheatThreshold": 90.0, 
+            "criticalThreshold": 95.0, 
+            "inAlertState": false, 
+            "relPos": "1", 
+            "alertCount": 0, 
+            "name": "TempSensor1"
+        }, 
+        {
+            "maxTemperature": 38.0, 
+            "maxTemperatureLastChange": 1473853425.4411056, 
+            "hwStatus": "ok", 
+            "currentTemperature": 35.0, 
+            "description": "CPU board temp sensor", 
+            "overheatThreshold": 75.0, 
+            "criticalThreshold": 80.0, 
+            "inAlertState": false, 
+            "relPos": "2", 
+            "alertCount": 0, 
+            "name": "TempSensor2"
+        } 
+    ],
     "systemStatus": "temperatureOk"
 }


### PR DESCRIPTION

Due to updates to the top command in 4.17:

* Fixes a bug where the regex used for ram would cause a stacktrace
* Fixes a bug where the regex for cpu usage would cause a stacktrace

These where older bugs and have never actually worked 

* Fixes a bug where onboard sensors where not displayed
* Fixes a bug where total ram was returned instead of available
* Fixes a bug where only cpu used by userspace was reported

Just to make things a bit easier to read.
* Clean up of overly nested loops

Do you guys want this as one large issue or as several issues ? 

Fixes #84 (adding this so the issue is closed automagically when this is merged)