### PR TITLE
Fixes various get_bgp_neighbors

### DIFF
--- a/test/unit/mocked_data/test_get_bgp_neighbors/issue58_neighbor_down/expected_result.json
+++ b/test/unit/mocked_data/test_get_bgp_neighbors/issue58_neighbor_down/expected_result.json
@@ -4,7 +4,7 @@
     "peers": {
       "192.168.56.4": {
         "is_enabled": true,
-        "uptime": 1452696202,
+        "uptime": "...",
         "remote_as": 65001,
         "description": "",
         "remote_id": "192.168.56.3",
@@ -25,7 +25,7 @@
       },
       "192.168.56.2": {
         "is_enabled": true,
-        "uptime": 1452680643,
+        "uptime": "...",
         "remote_as": 65002,
         "description": "",
         "remote_id": "192.168.56.2",
@@ -46,7 +46,7 @@
       },
       "2001:7f8::f10:0:2": {
         "is_enabled": true,
-        "uptime": 1452681618,
+        "uptime": "...",
         "remote_as": 65002,
         "description": "",
         "remote_id": "192.168.56.2",

--- a/test/unit/mocked_data/test_get_bgp_neighbors/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_bgp_neighbors/normal/expected_result.json
@@ -4,7 +4,7 @@
     "peers": {
       "192.168.56.4": {
         "is_enabled": true,
-        "uptime": 1452696202,
+        "uptime": "...",
         "remote_as": 65001,
         "description": "",
         "remote_id": "192.168.56.3",
@@ -25,7 +25,7 @@
       },
       "192.168.56.2": {
         "is_enabled": true,
-        "uptime": 1452680643,
+        "uptime": "...",
         "remote_as": 65002,
         "description": "",
         "remote_id": "192.168.56.2",
@@ -46,7 +46,7 @@
       },
       "2001:7f8::f10:0:2": {
         "is_enabled": true,
-        "uptime": 1452681618,
+        "uptime": "...",
         "remote_as": 65002,
         "description": "",
         "remote_id": "192.168.56.2",
@@ -67,7 +67,7 @@
       },
       "2001:7f8::f10:0:3": {
         "is_enabled": true,
-        "uptime": 1452696202,
+        "uptime": "...",
         "remote_as": 65001,
         "description": "",
         "remote_id": "192.168.56.3",


### PR DESCRIPTION
<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>

- The use of a for loop instead of while caused random data loss
  ( the actual cause of issue #58)<br>

- Peers that where idle would always have enable=False<br>

- Uptime was actually the timestamp of when the session started<br>


 - Use precompiled regex and more generic approach instead of a load of private methods<br>

<br><br>
This PR have 2 failing tests that might take some discussion to solve
<br><br>

1) Issue #58 is actually caused by the use of a for loop and the test data is invalid<br>
2) Since uptime is now calculated and not static, making the moc data wrong. The one way I came up with was mock time.time() in napalm-base, but this might have effects on other drivers so think it warrants some more thinking. <br>