### PR TITLE
Remove comma

### DIFF
--- a/napalm_eos/utils/textfsm_templates/vrf.tpl
+++ b/napalm_eos/utils/textfsm_templates/vrf.tpl
@@ -1,12 +1,17 @@
 Value Required Name (\S+)
 Value Route_Distinguisher (\d+:\d+|<not set>)
-Value List Interfaces (\S.+)
+Value List Interfaces (.+?)
 
 
 Start
   ^\s\S+\s+(\d|<) -> Continue.Record
-  ^\s+${Name}\s+${Route_Distinguisher}\s+(ipv4,ipv6\s+)?v4:(incomplete|(no )?routing(; multicast)?),\s+$Interfaces
-  ^\s+${Name}\s+${Route_Distinguisher}\s+(ipv4,ipv6\s+)?v4:(incomplete|(no )?routing(; multicast)?),
-  ^\s+v6:(incomplete|(no )?routing)\s+$Interfaces
-  ^\s+v6:(incomplete|(no )?routing) -> Record
-  ^\s+$Interfaces
+  ^\s+${Name}\s+${Route_Distinguisher}\s+(ipv4,ipv6\s+)?v4:(incomplete|(no )?routing(; multicast)?),\s+${Interfaces}(?:,|\s|$$) -> Continue
+  ^\s+\S+\s+(?:\d+:\d+|<not set>)\s+(ipv4,ipv6\s+)?v4:(incomplete|(no )?routing(; multicast)?),\s+(.+?),\s${Interfaces}(\s|,|$$) -> Continue
+  ^\s+\S+\s+(?:\d+:\d+|<not set>)\s+(ipv4,ipv6\s+)?v4:(incomplete|(no )?routing(; multicast)?),\s+(.+?),\s(.+?),\s${Interfaces}(\s|,|$$) -> Continue
+  ^\s+${Name}\s+${Route_Distinguisher}\s+(ipv4,ipv6\s+)?v4:(incomplete|(no )?routing(; multicast)?), -> Continue
+  ^\s{33,37}v6:(incomplete|(no )?routing)\s+${Interfaces}(?:\s|,|$$) -> Continue
+  ^\s{33,37}v6:(incomplete|(no )?routing)\s+(.+?),\s+${Interfaces}(?:\s|,|$$) -> Continue
+  ^\s{33,37}v6:(incomplete|(no )?routing)\s+(.+?),\s+(.+?),\s+${Interfaces}(?:\s|,|$$) -> Continue
+  ^\s{58,62}\s+${Interfaces}(?:\s|,|$$) -> Continue
+  ^\s{58,62}\s+.+?,${Interfaces}(?:\s|,|$$) -> Continue
+  ^\s{58,62}\s+.+?,.+?,${Interfaces}(?:\s|,|$$) -> Continue


### PR DESCRIPTION
Was unsure how some of this was working, (e.g. $Interfaces vs ${Interfaces} ) and see that the comma was left in. This PR is not ready to go in, just wanted to see if it made sense before adjusting the getter


Also @bewing are you ok to add this to ntc-templates? 

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
