### PR TITLE
WIP: Add _oc_platform private method

### DIFF
--- a/napalm_eos/eos.py
+++ b/napalm_eos/eos.py
@@ -1889,7 +1889,7 @@ class EOSDriver(NetworkDriver):
             "modelName": "part-no",
         }
         for card, details in inv.get("cardSlots", {}).items():
-            (card_class, num) = re.search("^[a-zA-Z]+)(\d+)", card).group(1, 2)
+            (card_class, num) = re.search("^([a-zA-Z]+)(\d+)", card).group(1, 2)
             if not card.startswith("Fabric"):
                 slot_map.update({int(num): card})
             has_cards = True

--- a/napalm_eos/eos.py
+++ b/napalm_eos/eos.py
@@ -1818,7 +1818,7 @@ class EOSDriver(NetworkDriver):
                     "type": "CHASSIS",
                     "description": inv['systemInformation']['description'],
                     "mfg-name": "Arista Networks",
-                    "version": inv['systemInformation'],
+                    "version": inv['systemInformation']['hardwareRev'],
                     "serial-no": inv['systemInformation']['serialNum'],
                     "part-no": plat_name,
                 },


### PR DESCRIPTION
Define a method to translate eAPI dictionaries into OpenConfig
platform information.

Used by napalm-automation/napalm-yang#38 EOS platform parser.

Still needs unit tests.

And yes, it could probably use 2 more refactoring passes.

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
