### PR TITLE
Fix optional_arg name for transport

### DIFF
--- a/napalm_eos/eos.py
+++ b/napalm_eos/eos.py
@@ -76,7 +76,8 @@ class EOSDriver(NetworkDriver):
         if optional_args is None:
             optional_args = {}
 
-        self.transport = optional_args.get('eos_transport', 'https')
+        # eos_transport is there for backwards compatibility, transport is the preferred method
+        self.transport = optional_args.get('transport', optional_args.get('eos_transport', 'https'))
 
         if self.transport == 'https':
             self.port = optional_args.get('port', 443)


### PR DESCRIPTION
Trying to be consistent with napalm-automation/napalm-ios/pull/159