### PR TITLE
Correct delete_users flow

### DIFF
--- a/napalm_eos/templates/delete_users.j2
+++ b/napalm_eos/templates/delete_users.j2
@@ -1,7 +1,8 @@
 {%- for user_name, user_details in users.items() %}
-{%- if user_details %}
+{%- if user_details is not none %}
 {%- if user_details.get('password') %}
 username {{user_name}} nopassword
+{%- endif %}
 {%- if user_details.get('level') %}
 no username {{user_name}} privilege {{user_details.level}}
 {%- endif %}


### PR DESCRIPTION
Before:
```python
In [5]: d.load_template("delete_users", users={"blahblahblah": None})
---------------------------------------------------------------------------
TemplateRenderException                   Traceback (most recent call last)
<ipython-input-5-e3124e6fdf99> in <module>()
----> 1 d.load_template("delete_users", users={"blahblahblah": None})

/home/bewing/.virtualenvs/napalm-eos/lib/python2.7/site-packages/napalm_base/base.pyc in load_template(self, template_name, template_source, template_path, **template_vars)
    136                                                  template_source=template_source,
    137                                                  template_path=template_path,
--> 138                                                  **template_vars)
    139
    140     def load_replace_candidate(self, filename=None, config=None):

/home/bewing/.virtualenvs/napalm-eos/lib/python2.7/site-packages/napalm_base/helpers.pyc in load_template(cls, template_name, template_source, template_path, openconfig, **template_vars)
     81             "Unable to render the Jinja config template {template_name}: {error}".format(
     82                 template_name=template_name,
---> 83                 error=jinjaerr.message
     84             )
     85         )

TemplateRenderException: Unable to render the Jinja config template delete_users: Encountered unknown tag 'endfor'. You probably made a nesting mistake. Jinja is expecting this tag, but currently looking for 'elif' or 'else' or 'endif'. The innermost block that needs to
be closed is 'if'.
```
After:
```python
In [5]: d.load_template("delete_users", users={"blahblahblah": None})
d
In [6]: print d.compare_config()
@@ -73,7 +73,6 @@
 no aaa root
 !
-username blahblahblah nopassword
 !
 clock timezone US/Central

In [7]: d.commit_config()
```